### PR TITLE
Fix native resolution in portrait mode

### DIFF
--- a/android-MAME4droid/app/src/main/java/com/seleuco/mame4droid/Emulator.java
+++ b/android-MAME4droid/app/src/main/java/com/seleuco/mame4droid/Emulator.java
@@ -325,7 +325,8 @@ public class Emulator {
 		window_width = Math.max(320, w);
 		window_height = Math.max(240, h);
 
-		setNativeSize(window_width, window_height);
+		if (Emulator.isEmulating)
+			setNativeSize(window_width, window_height);
 	}
 
 	// --- frame pacing + ADPF (v1, Java only) ---
@@ -850,7 +851,7 @@ public class Emulator {
 				resetFpsEstimator();
 
 				boolean extROM = false;
-				init(libPath, resPath);
+				init(libPath, resPath, window_width, window_height);
 				final String versionName = mm.getMainHelper().getVersion();
 				Emulator.setValueStr(Emulator.VERSION, versionName);
 
@@ -1064,7 +1065,7 @@ public class Emulator {
 	}
 
 	//native
-	protected static native void init(String libPath, String resPath);
+	protected static native void init(String libPath, String resPath, int nativeWidth, int nativeHeight);
 	protected static native void runT();
 	synchronized public static native void setDigitalData(int i, long data);
 	synchronized public static native void setAnalogData(int t, int i, float v1, float v2);

--- a/android-MAME4droid/app/src/main/java/com/seleuco/mame4droid/Emulator.java
+++ b/android-MAME4droid/app/src/main/java/com/seleuco/mame4droid/Emulator.java
@@ -201,16 +201,9 @@ public class Emulator {
 	private static final Paint debugPaint = new Paint();
 
 	private static int window_width = 320;
-
-	public static int getWindow_width() {
-		return window_width;
-	}
-
 	private static int window_height = 240;
 
-	public static int getWindow_height() {
-		return window_height;
-	}
+
 
 	private static int emu_width = 320;
 	private static int emu_height = 240;
@@ -327,12 +320,12 @@ public class Emulator {
 	}
 
 	//VIDEO
-	public static void setWindowSize(int w, int h) {
-
+	public static void onWindowSizeChanged(int w, int h) {
 		//System.out.println("window size "+w+" "+h);
+		window_width = Math.max(320, w);
+		window_height = Math.max(240, h);
 
-		window_width = w;
-		window_height = h;
+		setNativeSize(window_width, window_height);
 	}
 
 	// --- frame pacing + ADPF (v1, Java only) ---
@@ -857,8 +850,7 @@ public class Emulator {
 				resetFpsEstimator();
 
 				boolean extROM = false;
-				Size sz = mm.getMainHelper().getWindowSize();
-				init(libPath, resPath, Math.max(sz.getWidth(), sz.getHeight()), Math.min(sz.getWidth(), sz.getHeight()));
+				init(libPath, resPath);
 				final String versionName = mm.getMainHelper().getVersion();
 				Emulator.setValueStr(Emulator.VERSION, versionName);
 
@@ -1072,7 +1064,7 @@ public class Emulator {
 	}
 
 	//native
-	protected static native void init(String libPath, String resPath, int nativeWidth, int nativeHeight);
+	protected static native void init(String libPath, String resPath);
 	protected static native void runT();
 	synchronized public static native void setDigitalData(int i, long data);
 	synchronized public static native void setAnalogData(int t, int i, float v1, float v2);
@@ -1093,6 +1085,8 @@ public class Emulator {
 	public static native String[] getShaders();
 	public static native boolean setShader(String shader);
 	public static native int loadShaders(String path);
+
+	private static native void setNativeSize(int width, int height);
 
 	public static native int getGameRefreshMilliHz();
 

--- a/android-MAME4droid/app/src/main/java/com/seleuco/mame4droid/helpers/MainHelper.java
+++ b/android-MAME4droid/app/src/main/java/com/seleuco/mame4droid/helpers/MainHelper.java
@@ -1206,44 +1206,6 @@ galaxy sde	   --> 2560x1600 16:10
         return error;
     }
 
-	public Size getWindowSize(){
-		Size size;
-
-		if(Build.VERSION.SDK_INT < 30) {
-			Display display = mm.getWindowManager().getDefaultDisplay();
-			Point s = new Point();
-			display.getSize(s);
-			int width = s.x;
-			int height = s.y;
-			size= new Size(width,height);
-		}
-		else {
-			final WindowMetrics metrics = mm.getWindowManager().getCurrentWindowMetrics();
-			// Gets all excluding insets
-			final WindowInsets windowInsets = metrics.getWindowInsets();
-
-			final Rect bounds = metrics.getBounds();
-			size = new Size(bounds.width(), bounds.height());
-
-
-			if (!mm.getPrefsHelper().isNotchUsed()) {
-
-				Insets insets = windowInsets.getInsetsIgnoringVisibility(
-					//WindowInsets.Type.navigationBars()|
-					WindowInsets.Type.displayCutout());
-
-				int insetsWidth = insets.right + insets.left;
-				int insetsHeight = insets.top + insets.bottom;
-
-				size = new Size(size.getWidth() - insetsWidth, size.getHeight() - insetsHeight);
-			}
-		}
-
-		Log.d("SIZE","Window size is width:"+size.getWidth()+" height:"+size.getHeight());
-
-		return size;
-	}
-
 	public int getScreenOrientation(){
 		int orientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR;
 		switch (mm.getPrefsHelper().getOrientationMode()){

--- a/android-MAME4droid/app/src/main/java/com/seleuco/mame4droid/views/EmulatorViewGL.java
+++ b/android-MAME4droid/app/src/main/java/com/seleuco/mame4droid/views/EmulatorViewGL.java
@@ -388,7 +388,7 @@ public class EmulatorViewGL extends GLSurfaceView implements IEmuView {
 	@Override
 	protected void onSizeChanged(int w, int h, int oldw, int oldh) {
 		super.onSizeChanged(w, h, oldw, oldh);
-		Emulator.setWindowSize(w, h);
+		Emulator.onWindowSizeChanged(w, h);
 	}
 
 	/**

--- a/android-MAME4droid/app/src/main/jni/com_seleuco_mame4droid_Emulator.h
+++ b/android-MAME4droid/app/src/main/jni/com_seleuco_mame4droid_Emulator.h
@@ -156,7 +156,7 @@ extern "C" {
  * Signature: (Ljava/lang/String;Ljava/lang/String;II)V
  */
 JNIEXPORT void JNICALL Java_com_seleuco_mame4droid_Emulator_init
-  (JNIEnv *, jclass, jstring, jstring, jint, jint);
+  (JNIEnv *, jclass, jstring, jstring);
 
 /*
  * Class:     com_seleuco_mame4droid_Emulator

--- a/android-MAME4droid/app/src/main/jni/com_seleuco_mame4droid_Emulator.h
+++ b/android-MAME4droid/app/src/main/jni/com_seleuco_mame4droid_Emulator.h
@@ -156,7 +156,7 @@ extern "C" {
  * Signature: (Ljava/lang/String;Ljava/lang/String;II)V
  */
 JNIEXPORT void JNICALL Java_com_seleuco_mame4droid_Emulator_init
-  (JNIEnv *, jclass, jstring, jstring);
+  (JNIEnv *, jclass, jstring, jstring, jint, jint);
 
 /*
  * Class:     com_seleuco_mame4droid_Emulator

--- a/android-MAME4droid/app/src/main/jni/mame4droid-jni.c
+++ b/android-MAME4droid/app/src/main/jni/mame4droid-jni.c
@@ -47,7 +47,7 @@ void (*setAudioCallbacks)(void *func1,void *func2,void *func3)= NULL;
 void (*setVideoCallbacks)(void *func1,void *func2) = NULL;
 void (*setInputCallbacks)(void *func1) = NULL;
 void (*setDigitalData)(int i, unsigned long digital_status) = NULL;
-void (*initMyOSD)(const char *path) = NULL;
+void (*initMyOSD)(const char *path, int nativeWidth, int nativeHeight) = NULL;
 int (*netplayInit)(const char *server, int port, int join) = NULL;
 void (*setNetplayWarnCallback)(void *func1) = NULL;
 void (*netplaySetMode)(int mode) = NULL;
@@ -695,7 +695,7 @@ void* app_Thread_Start(void* args)
 }
 
 JNIEXPORT void JNICALL Java_com_seleuco_mame4droid_Emulator_init
-  (JNIEnv *env, jclass c,  jstring s1, jstring s2)
+  (JNIEnv *env, jclass c,  jstring s1, jstring s2, jint nativeWidth, jint nativeHeight)
 {
     __android_log_print(ANDROID_LOG_INFO, "mame4droid-jni", "init");
 
@@ -733,7 +733,7 @@ JNIEXPORT void JNICALL Java_com_seleuco_mame4droid_Emulator_init
     __android_log_print(ANDROID_LOG_INFO, "mame4droid-jni", "path %s",str2);
 
     if(initMyOSD!=NULL) {
-        initMyOSD(str2);
+        initMyOSD(str2, nativeWidth, nativeHeight);
     } else{
         __android_log_print(ANDROID_LOG_ERROR, "mame4droid-jni","Not initMyOSD!!!");
     }

--- a/android-MAME4droid/app/src/main/jni/mame4droid-jni.c
+++ b/android-MAME4droid/app/src/main/jni/mame4droid-jni.c
@@ -47,7 +47,7 @@ void (*setAudioCallbacks)(void *func1,void *func2,void *func3)= NULL;
 void (*setVideoCallbacks)(void *func1,void *func2) = NULL;
 void (*setInputCallbacks)(void *func1) = NULL;
 void (*setDigitalData)(int i, unsigned long digital_status) = NULL;
-void (*initMyOSD)(const char *path, int nativeWidth, int nativeHeight) = NULL;
+void (*initMyOSD)(const char *path) = NULL;
 int (*netplayInit)(const char *server, int port, int join) = NULL;
 void (*setNetplayWarnCallback)(void *func1) = NULL;
 void (*netplaySetMode)(int mode) = NULL;
@@ -79,6 +79,8 @@ int  (*setTouchData)(int i, int touchAction, float x, float y)=NULL;
 void (*onSurfaceCreated)(void) = NULL;
 int (*onDrawFrame)(int, int) = NULL;
 int (*newRenderer)() = NULL;
+
+void (*setNativeSize)(int, int) = NULL;
 
 void (*getShaders)(const char***, int*) = NULL;
 bool (*setShader)(const char*) = NULL;
@@ -192,6 +194,9 @@ static void load_lib(const char *str)
 
     setShader = dlsym(libdl, "myosd_video_setShader");
     __android_log_print(ANDROID_LOG_DEBUG, "mame4droid-jni", "myosd_video_setShader %d\n", setShader != NULL);
+
+    setNativeSize = dlsym(libdl, "myosd_video_set_native_size");
+    __android_log_print(ANDROID_LOG_DEBUG, "mame4droid-jni", "myosd_video_set_native_size %d\n", setNativeSize != NULL);
 
     getShaders = dlsym(libdl, "myosd_video_getShaders");
     __android_log_print(ANDROID_LOG_DEBUG, "mame4droid-jni", "myosd_video_getShaders %d\n", getShaders != NULL);
@@ -690,7 +695,7 @@ void* app_Thread_Start(void* args)
 }
 
 JNIEXPORT void JNICALL Java_com_seleuco_mame4droid_Emulator_init
-  (JNIEnv *env, jclass c,  jstring s1, jstring s2,jint nativeWidth, jint nativeHeight)
+  (JNIEnv *env, jclass c,  jstring s1, jstring s2)
 {
     __android_log_print(ANDROID_LOG_INFO, "mame4droid-jni", "init");
 
@@ -728,7 +733,7 @@ JNIEXPORT void JNICALL Java_com_seleuco_mame4droid_Emulator_init
     __android_log_print(ANDROID_LOG_INFO, "mame4droid-jni", "path %s",str2);
 
     if(initMyOSD!=NULL) {
-        initMyOSD(str2,nativeWidth, nativeHeight);
+        initMyOSD(str2);
     } else{
         __android_log_print(ANDROID_LOG_ERROR, "mame4droid-jni","Not initMyOSD!!!");
     }
@@ -1021,6 +1026,12 @@ JNIEXPORT void JNICALL Java_com_seleuco_mame4droid_Emulator_setRendererParameter
     free(values);
     free(jKeyStrs);
     free(jValStrs);
+}
+
+JNIEXPORT void JNICALL Java_com_seleuco_mame4droid_Emulator_setNativeSize
+        (JNIEnv *env, jclass c, jint width, jint height)
+{
+    setNativeSize(width, height);
 }
 
 JNIEXPORT jint JNICALL Java_com_seleuco_mame4droid_Emulator_netplayInit

--- a/src/osd/myosd/droid/myosd_droid.cpp
+++ b/src/osd/myosd/droid/myosd_droid.cpp
@@ -235,7 +235,8 @@ void myosd_droid_setSAFCallbacks(
     safCloseDir_callback = safCloseDir_java;
 }
 
-
+//Prototype
+static void droid_init(int nativeWidth, int nativeHeight);
 void myosd_droid_initMyOSD(const char *path, int nativeWidth, int nativeHeight) {
     __android_log_print(ANDROID_LOG_DEBUG, "libMAME4droid.so", "initMyOSD path: %s", path);
     /*ret = */chdir(path);

--- a/src/osd/myosd/droid/myosd_droid.cpp
+++ b/src/osd/myosd/droid/myosd_droid.cpp
@@ -236,9 +236,11 @@ void myosd_droid_setSAFCallbacks(
 }
 
 
-void myosd_droid_initMyOSD(const char *path) {
+void myosd_droid_initMyOSD(const char *path, int nativeWidth, int nativeHeight) {
     __android_log_print(ANDROID_LOG_DEBUG, "libMAME4droid.so", "initMyOSD path: %s", path);
     /*ret = */chdir(path);
+
+    droid_init(nativeWidth, nativeHeight);
 }
 
 static void droid_myosd_check_pause(void){
@@ -1077,9 +1079,11 @@ static void droid_init_res(int nativeWidth, int nativeHeight) {
     myosd_set(MYOSD_DISPLAY_HEIGHT_OSD, myosd_droid_res_height_osd);
 }
 
-static void droid_init(void) {
+static void droid_init(int nativeWidth, int nativeHeight) {
     if (!lib_inited) {
         __android_log_print(ANDROID_LOG_DEBUG, "MAME4droid.so", "init");
+
+        droid_init_res(nativeWidth, nativeHeight);
 
         droid_init_input();
 
@@ -1097,28 +1101,22 @@ int myosd_safOpenFile(const char *pathName,const char *mode) {
     return -1;
 }
 
-static bool res_inited = false;
 extern "C" void myosd_video_set_native_size(int nativeWidth, int nativeHeight) {
     __android_log_print(ANDROID_LOG_DEBUG, "libMAME4droid.so", "set_native_size nativeWidth: %d nativeHeight: %d",
                         nativeWidth, nativeHeight);
 
-    if (!res_inited) {
-        droid_init_res(nativeWidth, nativeHeight);
-        res_inited = true;
-    } else if (myosd_droid_resolution == 10 || myosd_droid_resolution_osd == 10) {
-        if (myosd_droid_resolution == 10) {
-            myosd_set(MYOSD_DISPLAY_WIDTH, nativeWidth);
-            myosd_set(MYOSD_DISPLAY_HEIGHT, nativeHeight);
-        }
-
-        if (myosd_droid_resolution_osd == 10) {
-            myosd_set(MYOSD_DISPLAY_WIDTH_OSD, nativeWidth);
-            myosd_set(MYOSD_DISPLAY_HEIGHT_OSD, nativeHeight);
-        }
-
-        //It's already updated through window.cpp
-        //droid_set_video_mode(nativeWidth, nativeHeight, nativeWidth, nativeHeight);
+     if (myosd_droid_resolution == 10) {
+        myosd_set(MYOSD_DISPLAY_WIDTH, nativeWidth);
+        myosd_set(MYOSD_DISPLAY_HEIGHT, nativeHeight);
     }
+
+    if (myosd_droid_resolution_osd == 10) {
+        myosd_set(MYOSD_DISPLAY_WIDTH_OSD, nativeWidth);
+        myosd_set(MYOSD_DISPLAY_HEIGHT_OSD, nativeHeight);
+    }
+
+    //It's already updated through window.cpp
+    //droid_set_video_mode(nativeWidth, nativeHeight, nativeWidth, nativeHeight);
 }
 
 int *myosd_safReadDir(const char *dirName, int reload) {
@@ -1449,8 +1447,6 @@ int myosd_droid_adjust_ui_font_rows(int current) {
 int myosd_droid_main(int argc, char **argv) {
 
     __android_log_print(ANDROID_LOG_DEBUG, "libMAME4droid.so", "*********** ANDROID MAIN ********");
-
-    droid_init();
 
     myosd_callbacks callbacks = {
             .output_text  = droid_output_cb,

--- a/src/osd/myosd/droid/myosd_droid.cpp
+++ b/src/osd/myosd/droid/myosd_droid.cpp
@@ -57,8 +57,6 @@ static int myosd_droid_res_width = 1;
 static int myosd_droid_res_height = 1;
 static int myosd_droid_res_width_osd = 1;
 static int myosd_droid_res_height_osd = 1;
-static int myosd_droid_res_width_native = 1;
-static int myosd_droid_res_height_native = 1;
 
 //input - save
 static int myosd_droid_num_buttons = 0;
@@ -238,15 +236,9 @@ void myosd_droid_setSAFCallbacks(
 }
 
 
-void myosd_droid_initMyOSD(const char *path, int nativeWidth, int nativeHeight) {
-
-    __android_log_print(ANDROID_LOG_DEBUG, "libMAME4droid.so", "initMyOSD path: %s nativeWidth: %d nativeHeight: %d", path,
-                        nativeWidth, nativeHeight);
-
+void myosd_droid_initMyOSD(const char *path) {
+    __android_log_print(ANDROID_LOG_DEBUG, "libMAME4droid.so", "initMyOSD path: %s", path);
     /*ret = */chdir(path);
-
-    myosd_droid_res_width_native = nativeWidth;
-    myosd_droid_res_height_native = nativeHeight;
 }
 
 static void droid_myosd_check_pause(void){
@@ -1029,59 +1021,65 @@ static void droid_map_keyboard(){
 
 }
 
+static void droid_init_res(int nativeWidth, int nativeHeight) {
+    int reswidth = 640, resheight = 480;
+    int reswidth_osd = 640, resheight_osd = 480;
+
+    /* Auto game resolution implies the low-res OSD (400x300). Derive a
+     * local effective value instead of writing back into the Java-owned
+     * resolution_osd, so it can't desync with setValue ordering. */
+    int eff_resolution_osd = (myosd_droid_resolution == 0) ? 0 : myosd_droid_resolution_osd;
+
+    switch (myosd_droid_resolution)
+    {
+        case 0:{reswidth = 0;resheight = 0;break;}//400x300 (4/3)
+        case 1:{reswidth = 640;resheight = 480;break;}//640x480 (4/3)
+        case 2:{reswidth = 800;resheight = 600;break;}//800x600 (4/3)
+        case 3:{reswidth = 1024;resheight = 768;break;}//1024x768 (4/3)
+        case 4:{reswidth = 1280;resheight = 720;break;}//1280x720 (16/9)
+        case 5:{reswidth = 1440;resheight = 1080;break;}//1440x1080 (4/3)
+        case 6:{reswidth = 1920;resheight = 1080;break;}//1920x1080 (16/9)
+        case 7:{reswidth = (nativeHeight / 2) * 4 / 3.0f ;resheight = nativeHeight / 2;break;}//fullscreen/2 (4/3)
+        case 8:{reswidth = nativeWidth / 2;resheight = nativeHeight / 2;break;}//fullscreen/2
+        case 9:{reswidth = nativeHeight * 4 / 3.0f ;resheight = nativeHeight;break;}//fullscreen (4/3)
+        case 10:{reswidth = nativeWidth;resheight = nativeHeight;break;}//fullscreen
+    }
+
+    switch (eff_resolution_osd)
+    {
+        case 0:{reswidth_osd = 400;resheight_osd = 300;break;}
+            // case 11:{reswidth_osd = 450;resheight_osd = 300;break;}
+        case 11:{reswidth_osd = 500;resheight_osd = 333;break;}
+            //case 11:{reswidth_osd = 510;resheight_osd = 300;break;}
+        case 1:{reswidth_osd = 640;resheight_osd = 480;break;}//640x480 (4/3)
+        case 2:{reswidth_osd = 800;resheight_osd = 600;break;}//800x600 (4/3)
+        case 3:{reswidth_osd = 1024;resheight_osd = 768;break;}//1024x768 (4/3)
+        case 4:{reswidth_osd = 1280;resheight_osd = 720;break;}//1280x720 (16/9)
+        case 5:{reswidth_osd = 1440;resheight_osd = 1080;break;}//1440x1080 (4/3)
+        case 6:{reswidth_osd = 1920;resheight_osd = 1080;break;}//1920x1080 (16/9)
+        case 7:{reswidth_osd = (nativeHeight / 2) * 4 / 3.0f ;resheight_osd = nativeHeight / 2;break;}//fullscreen/2 (4/3)
+        case 8:{reswidth_osd = nativeWidth / 2;resheight_osd = nativeHeight / 2;break;}//fullscreen/2
+        case 9:{reswidth_osd = nativeHeight * 4 / 3.0f ;resheight_osd = nativeHeight;break;}//fullscreen (4/3)
+        case 10:{reswidth_osd = nativeWidth;resheight_osd = nativeHeight;break;}//fullscreen
+    }
+
+    myosd_droid_res_width = reswidth;
+    myosd_droid_res_height = resheight;
+    myosd_droid_res_width_osd = reswidth_osd;
+    myosd_droid_res_height_osd = resheight_osd;
+
+    droid_set_video_mode(myosd_droid_res_width_osd, myosd_droid_res_height_osd,
+                         myosd_droid_res_width_osd, myosd_droid_res_height_osd);
+
+    myosd_set(MYOSD_DISPLAY_WIDTH, myosd_droid_res_width);
+    myosd_set(MYOSD_DISPLAY_HEIGHT, myosd_droid_res_height);
+    myosd_set(MYOSD_DISPLAY_WIDTH_OSD, myosd_droid_res_width_osd);
+    myosd_set(MYOSD_DISPLAY_HEIGHT_OSD, myosd_droid_res_height_osd);
+}
+
 static void droid_init(void) {
     if (!lib_inited) {
-
         __android_log_print(ANDROID_LOG_DEBUG, "MAME4droid.so", "init");
-
-        int reswidth = 640, resheight = 480;
-        int reswidth_osd = 640, resheight_osd = 480;
-
-        /* Auto game resolution implies the low-res OSD (400x300). Derive a
-         * local effective value instead of writing back into the Java-owned
-         * resolution_osd, so it can't desync with setValue ordering. */
-        int eff_resolution_osd = (myosd_droid_resolution == 0) ? 0 : myosd_droid_resolution_osd;
-
-        switch (myosd_droid_resolution)
-        {
-            case 0:{reswidth = 0;resheight = 0;break;}//400x300 (4/3)
-            case 1:{reswidth = 640;resheight = 480;break;}//640x480 (4/3)
-            case 2:{reswidth = 800;resheight = 600;break;}//800x600 (4/3)
-            case 3:{reswidth = 1024;resheight = 768;break;}//1024x768 (4/3)
-            case 4:{reswidth = 1280;resheight = 720;break;}//1280x720 (16/9)
-            case 5:{reswidth = 1440;resheight = 1080;break;}//1440x1080 (4/3)
-            case 6:{reswidth = 1920;resheight = 1080;break;}//1920x1080 (16/9)
-            case 7:{reswidth = (myosd_droid_res_height_native/2) * 4/3.0f ;resheight = myosd_droid_res_height_native/2;break;}//fullscreen/2 (4/3)
-            case 8:{reswidth = myosd_droid_res_width_native/2;resheight = myosd_droid_res_height_native/2;break;}//fullscreen/2
-            case 9:{reswidth = myosd_droid_res_height_native * 4/3.0f ;resheight = myosd_droid_res_height_native;break;}//fullscreen (4/3)
-            case 10:{reswidth = myosd_droid_res_width_native;resheight = myosd_droid_res_height_native;break;}//fullscreen
-        }
-
-        switch (eff_resolution_osd)
-        {
-            case 0:{reswidth_osd = 400;resheight_osd = 300;break;}
-           // case 11:{reswidth_osd = 450;resheight_osd = 300;break;}
-            case 11:{reswidth_osd = 500;resheight_osd = 333;break;}
-            //case 11:{reswidth_osd = 510;resheight_osd = 300;break;}
-            case 1:{reswidth_osd = 640;resheight_osd = 480;break;}//640x480 (4/3)
-            case 2:{reswidth_osd = 800;resheight_osd = 600;break;}//800x600 (4/3)
-            case 3:{reswidth_osd = 1024;resheight_osd = 768;break;}//1024x768 (4/3)
-            case 4:{reswidth_osd = 1280;resheight_osd = 720;break;}//1280x720 (16/9)
-            case 5:{reswidth_osd = 1440;resheight_osd = 1080;break;}//1440x1080 (4/3)
-            case 6:{reswidth_osd = 1920;resheight_osd = 1080;break;}//1920x1080 (16/9)
-            case 7:{reswidth_osd = (myosd_droid_res_height_native/2) * 4/3.0f ;resheight_osd = myosd_droid_res_height_native/2;break;}//fullscreen/2 (4/3)
-            case 8:{reswidth_osd = myosd_droid_res_width_native/2;resheight_osd = myosd_droid_res_height_native/2;break;}//fullscreen/2
-            case 9:{reswidth_osd = myosd_droid_res_height_native * 4/3.0f ;resheight_osd = myosd_droid_res_height_native;break;}//fullscreen (4/3)
-            case 10:{reswidth_osd = myosd_droid_res_width_native;resheight_osd = myosd_droid_res_height_native;break;}//fullscreen
-        }
-
-        myosd_droid_res_width = reswidth;
-        myosd_droid_res_height = resheight;
-        myosd_droid_res_width_osd = reswidth_osd;
-        myosd_droid_res_height_osd = resheight_osd;
-
-        droid_set_video_mode(myosd_droid_res_width_osd, myosd_droid_res_height_osd,
-                             myosd_droid_res_width_osd, myosd_droid_res_height_osd);
 
         droid_init_input();
 
@@ -1097,6 +1095,30 @@ int myosd_safOpenFile(const char *pathName,const char *mode) {
         return safOpenFile_callback(pathName, mode);
     }
     return -1;
+}
+
+static bool res_inited = false;
+extern "C" void myosd_video_set_native_size(int nativeWidth, int nativeHeight) {
+    __android_log_print(ANDROID_LOG_DEBUG, "libMAME4droid.so", "set_native_size nativeWidth: %d nativeHeight: %d",
+                        nativeWidth, nativeHeight);
+
+    if (!res_inited) {
+        droid_init_res(nativeWidth, nativeHeight);
+        res_inited = true;
+    } else if (myosd_droid_resolution == 10 || myosd_droid_resolution_osd == 10) {
+        if (myosd_droid_resolution == 10) {
+            myosd_set(MYOSD_DISPLAY_WIDTH, nativeWidth);
+            myosd_set(MYOSD_DISPLAY_HEIGHT, nativeHeight);
+        }
+
+        if (myosd_droid_resolution_osd == 10) {
+            myosd_set(MYOSD_DISPLAY_WIDTH_OSD, nativeWidth);
+            myosd_set(MYOSD_DISPLAY_HEIGHT_OSD, nativeHeight);
+        }
+
+        //It's already updated through window.cpp
+        //droid_set_video_mode(nativeWidth, nativeHeight, nativeWidth, nativeHeight);
+    }
 }
 
 int *myosd_safReadDir(const char *dirName, int reload) {
@@ -1446,11 +1468,6 @@ int myosd_droid_main(int argc, char **argv) {
             .game_exit = m4i_game_stop,
 */
     };
-
-    myosd_set(MYOSD_DISPLAY_WIDTH, myosd_droid_res_width);
-    myosd_set(MYOSD_DISPLAY_HEIGHT, myosd_droid_res_height);
-    myosd_set(MYOSD_DISPLAY_WIDTH_OSD, myosd_droid_res_width_osd);
-    myosd_set(MYOSD_DISPLAY_HEIGHT_OSD, myosd_droid_res_height_osd);
 
     static const char *args[255];
     int n = 0;

--- a/src/osd/myosd/droid/myosd_droid.cpp
+++ b/src/osd/myosd/droid/myosd_droid.cpp
@@ -1114,6 +1114,9 @@ extern "C" void myosd_video_set_native_size(int nativeWidth, int nativeHeight) {
     if (myosd_droid_resolution_osd == 10) {
         myosd_set(MYOSD_DISPLAY_WIDTH_OSD, nativeWidth);
         myosd_set(MYOSD_DISPLAY_HEIGHT_OSD, nativeHeight);
+    } else if (myosd_droid_resolution_osd == 9) { //fullscreen (4/3)
+        myosd_set(MYOSD_DISPLAY_WIDTH_OSD, nativeHeight * 4 / 3.0f);
+        myosd_set(MYOSD_DISPLAY_HEIGHT_OSD, nativeHeight);
     }
 
     //It's already updated through window.cpp

--- a/src/osd/myosd/myosdmain.cpp
+++ b/src/osd/myosd/myosdmain.cpp
@@ -47,10 +47,10 @@
 //============================================================
 // MYOSD globals
 //============================================================
-int myosd_display_width;
-int myosd_display_height;
-int myosd_display_width_osd;
-int myosd_display_height_osd;
+int myosd_display_width = 0;
+int myosd_display_height = 0;
+int myosd_display_width_osd = 0;
+int myosd_display_height_osd = 0;
 int myosd_bitmap_filtering;
 int myosd_vector_improved;
 


### PR DESCRIPTION
When you rotate your device to portrait mode,  the resolution will look stretched because MAME keeps rendering with landscape mode dimensions. This PR fixes it so that each configuration change MAME is updated with the new dimensions.

